### PR TITLE
implement profiles and ward addition:

### DIFF
--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -1,0 +1,25 @@
+import models from '../database/models';
+import response from '../helpers/response';
+
+const { Profiles } = models;
+
+/**
+ * @name edit
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ * @return {Object} User object
+ */
+const edit = async (req, res) => {
+  try {
+    const { id } = req.user;
+    const { bio, avatar } = req.body;
+    const [, profile] = await Profiles.update({ bio, avatar }, {
+      where: { userId: id }, returning: true, plain: true,
+    });
+    return response.ok(res, profile);
+  } catch (e) {
+    return response.internalServer(res, e);
+  }
+};
+
+export { edit };

--- a/app/controllers/ward.js
+++ b/app/controllers/ward.js
@@ -1,0 +1,20 @@
+import response from '../helpers/response';
+import createWard from '../helpers/ward';
+
+/**
+ * @name create
+ * @param {object} req - Express request object
+ * @param {object} res - Express response object
+ * @return {Object} Ward object
+ */
+const create = async (req, res) => {
+  try {
+    const { id } = req.user;
+    const ward = await createWard(req.body, id);
+    return response.created(res, ward);
+  } catch (e) {
+    return response.internalServer(res, e);
+  }
+};
+
+export { create };

--- a/app/database/migrations/20200627093328-create-users.js
+++ b/app/database/migrations/20200627093328-create-users.js
@@ -9,7 +9,6 @@ module.exports = {
     lastName: { type: Sequelize.STRING, allowNull: false },
     email: {
       type: Sequelize.STRING,
-      allowNull: false,
     },
     userType: {
       type: Sequelize.ENUM(

--- a/app/database/migrations/20200913152514-create-profiles.js
+++ b/app/database/migrations/20200913152514-create-profiles.js
@@ -1,0 +1,36 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Profiles', {
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: Sequelize.UUID,
+    },
+    userId: {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: { model: 'Users', key: 'id' },
+    },
+    parentId: {
+      type: Sequelize.UUID,
+      references: { model: 'Users', key: 'id' },
+    },
+    bio: {
+      type: Sequelize.TEXT,
+    },
+    avatar: {
+      type: Sequelize.STRING,
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    deletedAt: {
+      type: Sequelize.DATE,
+    },
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('Profiles'),
+};

--- a/app/database/models/profiles.js
+++ b/app/database/models/profiles.js
@@ -1,0 +1,37 @@
+import { v4 as uuidv4 } from 'uuid';
+
+module.exports = (sequelize, DataTypes) => {
+  const Profiles = sequelize.define('Profiles', {
+    id: { type: DataTypes.UUID, primaryKey: true },
+    userId: { type: DataTypes.UUID, allowNull: false },
+    parentId: { type: DataTypes.UUID },
+    bio: DataTypes.TEXT,
+    avatar: DataTypes.STRING,
+  }, {
+    sequelize,
+    paranoid: true,
+  });
+  Profiles.beforeCreate((profile) => {
+    profile.id = uuidv4();
+  });
+
+  Profiles.getDetailByUserId = function getDetail(userId) {
+    return this.findOne({
+      where: { userId },
+      include: ['user'],
+    });
+  };
+
+  Profiles.associate = (models) => {
+    // associations can be defined here
+    Profiles.belongsTo(models.Users, {
+      foreignKey: 'userId',
+      as: 'user',
+    });
+    Profiles.belongsTo(models.Users, {
+      foreignKey: 'parentId',
+      as: 'parent',
+    });
+  };
+  return Profiles;
+};

--- a/app/database/models/users.js
+++ b/app/database/models/users.js
@@ -7,7 +7,6 @@ module.exports = (sequelize, DataTypes) => {
     lastName: { type: DataTypes.STRING, allowNull: false },
     email: {
       type: DataTypes.STRING,
-      allowNull: false,
       validate: { isEmail: true },
     },
     userType: {
@@ -32,7 +31,7 @@ module.exports = (sequelize, DataTypes) => {
   });
   Users.getDetail = function getDetail(user, withCredential = false) {
     const where = user && user.id ? { id: user.id } : { email: user.email };
-    let include = []; // Add all models to be included here
+    let include = ['profile']; // Add all models to be included here
     if (withCredential) include = include.concat('credential');
     return this.findOne({
       where,
@@ -45,11 +44,28 @@ module.exports = (sequelize, DataTypes) => {
   Users.getDetailByEmail = function getDetailByEmail(email, withCredential = false) {
     return this.getDetail({ email }, withCredential);
   };
+  Users.getWardByDetails = function getDetailByEmail(obj, withCredential = false) {
+    let include = ['profile']; // Add all models to be included here
+    if (withCredential) include = include.concat('credential');
+    return this.findOne({
+      where: { ...obj },
+      include,
+    });
+  };
+
   Users.associate = function associations(models) {
     // associations can be defined here
     Users.hasOne(models.Credentials, {
       foreignKey: 'userId',
       as: 'credential',
+    });
+    Users.hasOne(models.Profiles, {
+      foreignKey: 'userId',
+      as: 'profile',
+    });
+    Users.hasMany(models.Profiles, {
+      foreignKey: 'parentId',
+      as: 'parent',
     });
   };
   return Users;

--- a/app/helpers/auth.js
+++ b/app/helpers/auth.js
@@ -4,7 +4,9 @@ import jwtHelper from './jwt';
 import env from '../config/env';
 
 const { APP_URL, APP_PROTOCOL } = env;
-const { Users, Credentials, sequelize } = models;
+const {
+  Users, Credentials, sequelize, Profiles,
+} = models;
 
 /**
  * @name getBaseDomainFromUrl
@@ -121,6 +123,7 @@ const signUp = async (rawUser = {}) => {
   try {
     let newUser = await Users.create(user, { transaction: t });
     await Credentials.create({ password, userId: newUser.id, phoneNumber }, { transaction: t });
+    await Profiles.create({ userId: newUser.id }, { transaction: t }); // Create profile for all new users
     await t.commit();
     newUser = await Users.getDetailById(newUser.id, true);
     reply.user = newUser.get({ plain: true });

--- a/app/helpers/ward.js
+++ b/app/helpers/ward.js
@@ -1,0 +1,51 @@
+import models from '../database/models';
+
+const {
+  Users, sequelize, Profiles,
+} = models;
+
+/**
+ * @name createWard
+ * @param {Object} rawWard the platform the request is coming from
+ * @param {Object} parentId id of the parent of the ward
+ * @return {Object|Error} User details
+ */
+const createWard = async (rawWard, parentId) => {
+  const errorObject = {
+    subCode: 0,
+  };
+
+  const transaction = await sequelize.transaction();
+  const {
+    avatar, ...otherWardData
+  } = { ...rawWard };
+  const user = { ...otherWardData, userType: 'School_Student' };
+  const profileData = { parentId };
+
+  const existingWard = await Users.getWardByDetails({ ...otherWardData });
+
+  if (existingWard) {
+    const profile = await Profiles.getDetailByUserId(existingWard.id);
+    if (profile && profile.parentId === parentId) {
+      errorObject.message = 'Ward already exist';
+      errorObject.code = 409;
+      throw errorObject;
+    }
+  }
+  try {
+    let newUser = await Users.create(user, { transaction });
+    if (avatar) {
+      profileData.avatar = avatar;
+    }
+    await Profiles.create({ userId: newUser.id, ...profileData }, { transaction }); // Create profile for all new users
+    await transaction.commit();
+    newUser = await Users.getDetailById(newUser.id, true);
+    const newWard = newUser.get({ plain: true });
+    return newWard;
+  } catch (e) {
+    await transaction.rollback();
+    throw e;
+  }
+};
+
+export default createWard;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,6 +2,8 @@ import express from 'express';
 import response from '../helpers/response';
 import controllers from '../controllers';
 import userRoute from './user';
+import profileRoute from './profile';
+import wardRoute from './ward';
 import cache, { redisClient } from '../helpers/cache';
 import guard from '../middlewares/guard';
 
@@ -20,5 +22,9 @@ routes.post('/auth/sign-up', controllers.signUp);
 routes.post('/auth/sign-in', controllers.signIn);
 
 routes.use('/users', guard.requireAuthentication, userRoute);
+
+routes.use('/profiles', guard.requireAuthentication, profileRoute);
+
+routes.use('/wards', guard.requireAuthentication, wardRoute);
 
 export default routes;

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as profileController from '../controllers/profile';
+
+const routes = express.Router();
+
+routes.post('/edit', profileController.edit); // edit profile
+
+export default routes;

--- a/app/routes/ward.js
+++ b/app/routes/ward.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import * as wardController from '../controllers/ward';
+
+const routes = express.Router();
+
+routes.post('/create', wardController.create);
+
+export default routes;

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -65,4 +65,26 @@ describe('Authentication tests', () => {
       .send({ email: newUser.email, password: newUser.password })
       .end(authExpectations(200, 'Ok', done));
   });
+
+  it('Should create a new user with a profile', (done) => {
+    const newUser1 = {
+      email: faker.internet.email(),
+      firstName: faker.name.firstName(),
+      lastName: faker.name.lastName(),
+      userType: faker.random.arrayElement(userTypes),
+      password: '1234567890dy&%$#',
+    };
+    chai
+      .request(server)
+      .post(`${baseAPIUrl}/auth/sign-up`)
+      .send(newUser1)
+      .end((error, response) => {
+        const { status, body: { data = {} }, body } = response || {};
+        expect(status).to.equal(201);
+        expect(body).to.have.keys(['code', 'message', 'data']);
+        expect(data.firstName).to.equal(newUser1.firstName);
+        expect(data.profile.userId).to.equal(data.id);
+        done();
+      });
+  });
 });

--- a/test/profile.spec.js
+++ b/test/profile.spec.js
@@ -1,0 +1,83 @@
+import chai, { expect } from 'chai';
+import faker from 'faker';
+import chaiHttp from 'chai-http';
+import server from '../index';
+
+chai.use(chaiHttp);
+chai.should();
+
+const userTypes = [
+  'Student_Guardian',
+  'School_Admin',
+  'School_Staff',
+  'School_Student',
+];
+
+const baseAPIUrl = '/api/v1';
+const profileBaseUrl = `${baseAPIUrl}/profiles`;
+let token, user;
+
+before(() => {
+  const newUser = {
+    email: faker.internet.email(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    userType: faker.random.arrayElement(userTypes),
+    password: '1234567890dy&%$#',
+  };
+  chai
+    .request(server)
+    .post(`${baseAPIUrl}/auth/sign-up`)
+    .send(newUser)
+    .end((error, response) => {
+      token = response.header.authorization;
+      user = response.body.data;
+    });
+});
+
+/**
+   * @name newWard
+   * @returns {Object} a new ward object
+   */
+const newProfileData = () => ({
+  bio: faker.lorem.paragraphs(),
+  avatar: faker.image.avatar(),
+  parentId: faker.random.uuid(),
+});
+
+describe('Edit Profile Test', () => {
+  context('When a user request for is detail to be updated', () => {
+    it('updates only the editable fields', (done) => {
+      const profile = newProfileData();
+      chai
+        .request(server)
+        .post(`${profileBaseUrl}/edit`)
+        .set('Authorization', token)
+        .send(profile)
+        .end((error, response) => {
+          const { status, body: { data = {} }, body } = response || {};
+          expect(status).to.equal(200);
+          expect(body).to.have.keys(['code', 'message', 'data']);
+          expect(data.bio).to.equal(profile.bio);
+          expect(data.parentId).not.to.equal(profile.parentId);
+          done();
+        });
+    });
+  });
+
+  context('When a wrong data type is sent', () => {
+    it('throws an error', (done) => {
+      chai
+        .request(server)
+        .post(`${profileBaseUrl}/edit`)
+        .set('Authorization', token)
+        .send({ bio: [] })
+        .end((error, response) => {
+          const { status, body } = response || {};
+          expect(status).to.equal(500);
+          expect(body).to.have.keys(['code', 'message', 'error']);
+          done();
+        });
+    });
+  });
+});

--- a/test/ward.spec.js
+++ b/test/ward.spec.js
@@ -1,0 +1,125 @@
+import chai, { expect } from 'chai';
+import faker from 'faker';
+import chaiHttp from 'chai-http';
+import server from '../index';
+
+chai.use(chaiHttp);
+chai.should();
+
+const userTypes = [
+  'Student_Guardian',
+  'School_Admin',
+  'School_Staff',
+  'School_Student',
+];
+
+const gender = [
+  'male',
+  'female',
+  'other',
+];
+const baseAPIUrl = '/api/v1';
+const wardBaseUrl = `${baseAPIUrl}/wards`;
+let auth;
+
+before((done) => {
+  const newUser = {
+    email: faker.internet.email(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    userType: faker.random.arrayElement(userTypes),
+    password: '1234567890dy&%$#',
+  };
+  chai
+    .request(server)
+    .post(`${baseAPIUrl}/auth/sign-up`)
+    .send(newUser)
+    .end((error, response) => {
+      auth = response.header.authorization;
+      done();
+    });
+});
+
+/**
+   * @name newWard
+   * @returns {Object} a new ward object
+   */
+const newWard = () => ({
+  firstName: faker.name.firstName(),
+  lastName: faker.name.lastName(),
+  avatar: faker.image.avatar(),
+  gender: faker.random.arrayElement(gender),
+  schoolId: faker.random.uuid(),
+});
+
+describe('Create Ward Test', () => {
+  const ward = newWard();
+  context('When a parent request for a ward to be added', () => {
+    it('adds the ward and associates the ward to the parent', (done) => {
+      chai
+        .request(server)
+        .post(`${wardBaseUrl}/create`)
+        .set('Authorization', auth)
+        .send(ward)
+        .end((error, response) => {
+          const { status, body: { data = {} }, body } = response || {};
+          expect(status).to.equal(201);
+          expect(body).to.have.keys(['code', 'message', 'data']);
+          expect(data.firstName).to.equal(ward.firstName);
+          done();
+        });
+    });
+  });
+
+  context('When a request with duplicate data is made', () => {
+    it('throws an error', (done) => {
+      chai
+        .request(server)
+        .post(`${wardBaseUrl}/create`)
+        .set('Authorization', auth)
+        .send(ward)
+        .end((error, response) => {
+          const { status, body: { error: errorObject = {} }, body } = response || {};
+          expect(status).to.equal(500);
+          expect(body).to.have.keys(['code', 'message', 'error']);
+          expect(errorObject.code).to.equal(409);
+          expect(errorObject.message).to.equal('Ward already exist');
+          done();
+        });
+    });
+  });
+
+  context('When avatar data is missing', () => {
+    const ward1 = newWard();
+    delete ward1.avatar;
+    it('creates ward', (done) => {
+      chai
+        .request(server)
+        .post(`${wardBaseUrl}/create`)
+        .set('Authorization', auth)
+        .send(ward1)
+        .end((error, response) => {
+          const { status, body: { data = {} }, body } = response || {};
+          expect(status).to.equal(201);
+          expect(body).to.have.keys(['code', 'message', 'data']);
+          expect(data.firstName).to.equal(ward1.firstName);
+          done();
+        });
+    });
+  });
+
+  context('When no data is sent', () => {
+    it('throws an error', (done) => {
+      chai
+        .request(server)
+        .post(`${wardBaseUrl}/create`)
+        .set('Authorization', auth)
+        .end((error, response) => {
+          const { status, body } = response || {};
+          expect(status).to.equal(500);
+          expect(body).to.have.keys(['code', 'message', 'error']);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Implement functionality for profile creation and update and also for ward addition

#### Description of Task proposed in this pull request?
- user profile is created on signup
- users can update their profile
- parents can add their ward

#### How should this be manually tested (Quality Assurance)?
- checkout to `ft-create-update-profile`
- run tests using `npm test`
OR
- make a request to `POST /profile/edit` to edit profile. Editable fields are bio and avatar.
- sign up to test profile creation
- make a request to `POST /ward/create` to add a ward.

#### What are the relevant pivotal tracker stories?
- [#172622119](https://www.pivotaltracker.com/story/show/172622119)
- [#172623030](https://www.pivotaltracker.com/story/show/172623030)

#### Any background context you want to add (Operations Impact)?
- N/A.

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
